### PR TITLE
Fetch books via API route rather than importing the sample data

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,10 +11,21 @@ const Layout: React.FC = ({ children }) => (
       <meta lang="en" />
     </Head>
     <header className="my-6">
-      <nav className="text-center">
-        <Link href="/">Home</Link> | <Link href="/about">About</Link> |{" "}
-        <Link href="/bookshelf">Bookshelf</Link> |{" "}
-        <Link href="/api/books">Books API</Link>
+      <nav>
+        <ul className="list-none flex justify-center gap-6">
+          <li>
+            <Link href="/">Home</Link>
+          </li>
+          <li>
+            <Link href="/about">About</Link>
+          </li>
+          <li>
+            <Link href="/bookshelf">Bookshelf</Link>
+          </li>
+          <li>
+            <Link href="/api/books">Books API</Link>
+          </li>
+        </ul>
       </nav>
       <hr className="mt-6" />
     </header>

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -1,15 +1,11 @@
 import NextLink, { LinkProps } from "next/link";
 
-interface Props extends Omit<LinkProps, "href"> {
-  href: string;
-}
-
-const Link: React.FC<Props> = ({ children, href, ...rest }) => {
-  const isExternal: boolean = href.startsWith("http");
+const Link: React.FC<LinkProps> = ({ children, href, ...rest }) => {
+  const isExternal: boolean = String(href).startsWith("http");
 
   if (isExternal) {
     return (
-      <a href={href} className="text-blue-900 hover:text-blue-700">
+      <a href={String(href)} className="text-blue-900 hover:text-blue-700">
         {children}
       </a>
     );

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -1,11 +1,3 @@
-/**
- * You can include shared interfaces/types in a separate file
- * and then use them in any component by importing them. For
- * example, to import the interface below do:
- *
- * import { Book } from 'path/to/interfaces';
- */
-
 export type Book = {
   id: number;
   name: string;

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -7,10 +7,11 @@ const About: React.FC = () => (
       This is a boilerplate Next.js website using Tailwind CSS and TypeScript.
     </p>
     <p>
-      You can find the source on{" "}
+      The source is on{" "}
       <Link href="https://github.com/robinmetral/next-with-tailwindcss-typescript">
         GitHub
       </Link>
+      .
     </p>
   </>
 );

--- a/pages/api/books/index.ts
+++ b/pages/api/books/index.ts
@@ -4,9 +4,8 @@ import { sampleBooksData } from "../../../utils/sample-data";
 const handler = (_req: NextApiRequest, res: NextApiResponse): void => {
   try {
     if (!Array.isArray(sampleBooksData)) {
-      throw new Error("Cannot find books data");
+      throw new Error("Couldn't find books");
     }
-
     res.status(200).json(sampleBooksData);
   } catch (err) {
     res.status(500).json({ statusCode: 500, message: err.message });

--- a/pages/bookshelf/[id].tsx
+++ b/pages/bookshelf/[id].tsx
@@ -2,7 +2,7 @@ import { GetStaticProps, GetStaticPaths } from "next";
 import Link from "../../components/Link";
 
 import { Book } from "../../interfaces";
-import { sampleBooksData } from "../../utils/sample-data";
+import { fetchBooks } from "../../utils/books-service";
 
 const BookDetail: React.FC<{ book: Book }> = ({ book }) => (
   <>
@@ -21,12 +21,13 @@ export default BookDetail;
  * https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
  */
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = sampleBooksData.map((book) => ({
+  const books = await fetchBooks();
+  const paths = books.map((book) => ({
     params: { id: book.id.toString() },
   }));
   return {
     paths,
-    fallback: false, // show a 404 if that path doesn't exist
+    fallback: false,
   };
 };
 
@@ -35,7 +36,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
  * https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const books = await fetchBooks();
   const id = params?.id;
-  const book = sampleBooksData.find((data) => data.id === Number(id));
+  const book = books.find((data) => data.id === Number(id));
   return { props: { book } };
 };

--- a/pages/bookshelf/index.tsx
+++ b/pages/bookshelf/index.tsx
@@ -1,8 +1,8 @@
 import { GetStaticProps } from "next";
 
 import { Book } from "../../interfaces";
-import { sampleBooksData } from "../../utils/sample-data";
 import Link from "../../components/Link";
+import { fetchBooks } from "../../utils/books-service";
 
 const Bookshelf: React.FC<{ books: Book[] }> = ({ books }) => (
   <>
@@ -28,7 +28,7 @@ const Bookshelf: React.FC<{ books: Book[] }> = ({ books }) => (
 );
 
 export const getStaticProps: GetStaticProps = async () => {
-  const books: Book[] = sampleBooksData;
+  const books: Book[] = await fetchBooks();
   return { props: { books } };
 };
 

--- a/utils/books-service.ts
+++ b/utils/books-service.ts
@@ -1,0 +1,12 @@
+import { Book } from "../interfaces";
+import { API_URL } from "./env";
+
+export async function fetchBooks(): Promise<Book[]> {
+  try {
+    const response = await fetch(`${API_URL}/api/books`);
+    const books: Book[] = await response.json();
+    return books;
+  } catch (error) {
+    throw new Error(`Error fetching books: ${error}`);
+  }
+}

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,0 +1,4 @@
+export const API_URL =
+  process.env.NODE_ENV === "production"
+    ? "https://next-with-tailwindcss-typescript.vercel.app/"
+    : "http://localhost:3000";


### PR DESCRIPTION
This makes the example closer to a real use case by fetching books via the API route.

This is more similar to how a real website would fetch data from an API.

The commit also introduces an `API_URL` based on the environment (dev/prod), which could be replaced by different API URLs per env.
